### PR TITLE
Add byte metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const DEFAULT_NO_NAME = 'NO_NAME'
 class Hypermetrics {
   constructor (client, opts = {}) {
     this.client = client
+    this.detailed = !!opts.detailed
+
     this._cores = [] // TODO change to set
     this._names = new Map()
     this._labelNames = ['key', 'type', 'name']
-    this.detailed = !!opts.detailed
 
     const self = this
 

--- a/test.js
+++ b/test.js
@@ -40,6 +40,20 @@ test('Returns expected metrics', async t => {
   t.alike(metricNames, expectedMetrics, 'Has all expected metrics')
 })
 
+test('Returns detailed metrics when set', async t => {
+  promClient.register.clear()
+  const store = new Corestore(RAM)
+  const core = store.get({ name: 'core' })
+  await core.ready()
+
+  const metrics = new HyperMetrics(promClient, { detailed: true })
+  metrics.add(core)
+  const metricNames = new Set((await metrics.getMetricsAsJSON()).map(entry => entry.name))
+
+  t.ok(metricNames.has('hypercore_peer_downloaded_bytes'), 'hypercore_peer_downloaded_bytes included')
+  t.ok(metricNames.has('hypercore_peer_uploaded_bytes'), 'hypercore_peer_uploaded_bytes included')
+})
+
 test('basic length metric', async (t) => {
   promClient.register.clear()
   const metrics = new HyperMetrics(promClient)

--- a/test.js
+++ b/test.js
@@ -32,7 +32,9 @@ test('Returns expected metrics', async t => {
     'hypercore_uploaded_blocks',
     'hypercore_downloaded_blocks',
     'hypercore_nr_inflight_blocks',
-    'hypercore_max_inflight_blocks'
+    'hypercore_max_inflight_blocks',
+    'hypercore_uploaded_bytes',
+    'hypercore_downloaded_bytes'
   ])
 
   t.alike(metricNames, expectedMetrics, 'Has all expected metrics')


### PR DESCRIPTION
The per-peer metrics are opt-in, because as-is they can take up a lot of memory: there is one line per peer. Since the amount of peers keeps growing over the lifetime of an application, the metrics would also keep growing.

I'd keep the metrics behind the 'detailed' flags unofficial for now, until I've iterated on this some more, but would already like to get it in as it's an interesting metric.